### PR TITLE
Fix DND binary sensor rule

### DIFF
--- a/packages/centro_notifiche/hub_main.yaml
+++ b/packages/centro_notifiche/hub_main.yaml
@@ -306,7 +306,7 @@ binary_sensor:
           {%set start=state_attr('input_datetime.dnd_start_%s'%day,'timestamp')%}
           {%set stop=state_attr('input_datetime.dnd_end_%s'%day,'timestamp')%}
           {%if speech=='on' and priority=='off'%} 
-          {{(start<t<stop) if start<stop else (t>start or t<stop)}}
+          {{(start<t<stop) if start<stop else ((t>start or t<stop) and start != stop)}}
           {%elif speech=='off' and priority=='off'%}True{%else%}False{%endif%}
         icon_template: >
           {%if is_state('binary_sensor.dnd','off')%}mdi:do-not-disturb-off{%else%}mdi:do-not-disturb{%endif%}


### PR DESCRIPTION
if the start and stop times of the DND period are the same, the binary DND sensor is always true, but it is wrong.
How to reproduce it:
set start = 00:00 and stop = 00:00 at any time, the binary sensor DND is set to True